### PR TITLE
Fixed bug preventing Prefernces from displaying

### DIFF
--- a/src/main/java/memoranda/util/MimeType.java
+++ b/src/main/java/memoranda/util/MimeType.java
@@ -132,7 +132,7 @@ public class MimeType {
             icon = new ImageIcon(main.java.memoranda.ui.AppFrame.class.getResource(ip));
           }
           catch (Exception ex2) {
-            icon = new ImageIcon(main.java.memoranda.ui.AppFrame.class.getResource("/util/icons/mimetypes/default.png"));
+            icon = new ImageIcon(main.java.memoranda.ui.AppFrame.class.getResource("/ui/icons/mimetypes/default.png"));
           }
         }
       }


### PR DESCRIPTION
Only had to change "util" to "ui" on line 135 of src/main/java/memoranda/util/MimeType.java so that it would pull the correct icon file and be able to finish displaying the preferenes dialog box. Previously, it threw a NullPointerException because there was no such icon in the util folder. It's probable the original devs simply made a typo and meant "ui."